### PR TITLE
Export ListenerType

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export type EEMethodReturnType<
   FValue = void
 > = S extends keyof T ? InnerEEMethodReturnType<T[S], TValue, FValue> : FValue;
 
-type ListenerType<T> = [T] extends [(...args: infer U) => any]
+export type ListenerType<T> = [T] extends [(...args: infer U) => any]
   ? U
   : [T] extends [void] ? [] : [T];
 


### PR DESCRIPTION
Hello, thanks for providing a useful library. It has helped me a lot.

I am writing a code to wrap this library and I ran into a problem when trying to hook ListenerType, because is not exported.

Since ListenerType is not exported, it can't be used from outside.

So, I opened this PR to add the export statement.

If there is a specific reason for why it isn't currently being exported, please feel free to close this PR.

This is what I want to do.

```typescript
interface MyEvent {
    someEvent: string,
}

const eventEmitter: StrictEventEmitter<EventEmitter, MyEvent> = new EventEmitter();

const addListener = <P extends keyof MyEvent>(eventName: P, listener: (...args: ListenerType<MyEvent[P]>) => void) => {
    someHookFunction(eventName);
    eventEmitter.addListener(eventName, listener);
};

addListener('someEvent', (str: string) => {
    console.log(str);
});
```

Thank you.