### PR TITLE
Override 'off' method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,17 @@ export type OverriddenMethods<
     ...args: ListenerType<TEmitRecord[P]>
   ): EEMethodReturnType<TEmitter, 'emit', T>;
   emit(event: typeof assignmentCompatibilityHack, ...args: any[]): void;
+  
+  
+  off<P extends keyof TEventRecord, T>(
+    this: T,
+    event: P,
+    listener: (...args: ListenerType<TEventRecord[P]>) => void
+  ): EEMethodReturnType<TEmitter, 'off', T>;
+  off(
+    event: typeof assignmentCompatibilityHack,
+    listener: (...args: any[]) => any
+  ): void;
 };
 
 export type OverriddenKeys = keyof OverriddenMethods<any, any, any>;


### PR DESCRIPTION
[off](https://nodejs.org/api/events.html#events_emitter_off_eventname_listener) method has not been overridden.

This is needed more for consistency `'on'` / ` 'off'`, like for `'addListener'` / `'removeListener'`.